### PR TITLE
class P: Use static_cast for type checking (into master).

### DIFF
--- a/CoreLibrary/base.h
+++ b/CoreLibrary/base.h
@@ -103,7 +103,7 @@ public:
   C *operator ->() const;
   template<class D> operator D *() const {
 
-    return (D *)object;
+    return static_cast<D *>((C *)object);
   }
   bool operator ==(C *c) const;
   bool operator !=(C *c) const;

--- a/CoreLibrary/base.tpl.cpp
+++ b/CoreLibrary/base.tpl.cpp
@@ -142,7 +142,7 @@ template<class C> inline P<C>& P<C>::operator =(C *c) {
 
 template<class C> template<class D> inline P<C> &P<C>::operator =(const P<D> &p) {
 
-  return this->operator =((C *)p.object);
+  return this->operator =(static_cast<C *>((D *)p.object));
 }
 
 template<class C> inline P<C> &P<C>::operator =(const P<C> &p) {


### PR DESCRIPTION
(This is the same as pull request #3, but this one is merged into master.)

The class P<C> holds a pointer to an object of type C. It [implements `operator*`](https://github.com/IIIM-IS/CoreLibrary/blob/5f1eb8d7c0a3fd2a15706ed2f50a761ade6870ac/CoreLibrary/base.h#L106) to get the pointer:

    template<class C> class P {
      ...
      template<class D> operator D *() const {
        return (D *)object;
      }
    }

The result is declared as type D so that the object can be cast to a base type. For example:

    class Dog {};
    class Beagle : public Dog {};
    P<Beagle> snoopy;
    Dog *dog = snoopy;

The last line gets the object of type `Beagle*` pointed to by `snoopy` using `operator*` and sets it to the variable `dog` which is of type `Dog*`. But that is OK since `Dog` is a base class of type `Beagle`.

But the following code also compiles:

   Cat *cat = snoopy;

The classes `Cat` and `Dog` are unrelated, but the `operator*` uses `(D *)` and so forces the cast without type checking. This can cause a crash when accessing members of the wrong type of object. 

This pull request changes `operator*` to use `static_cast` to do this type checking. The compiled code is the same and runs at the same speed, but now we have compile-time type checking. The compiler will give an error in the example above. We also use `static_cast` in the [assignment `operator=`](https://github.com/IIIM-IS/CoreLibrary/blob/5f1eb8d7c0a3fd2a15706ed2f50a761ade6870ac/CoreLibrary/base.tpl.cpp#L145) for similar reasons.

Note: This problem was discovered in the [following code in `GMonitor::reduce`](https://github.com/IIIM-IS/replicode/blob/f331284fc07bd416b8318db9f2686b5234984706/r_exec/g_monitor.cpp#L246): 

    prediction->get_simulation(target);

The `get_simulation` method takes an argument of type `Controller*`. But `target` is of type `P<Fact>`. This is clearly a typo. The fix in this pull request makes the compiler catch this error.)