### PR TITLE
global: Spell member variables with a trailing underscore

### DIFF
--- a/CoreLibrary/base.cpp
+++ b/CoreLibrary/base.cpp
@@ -86,10 +86,10 @@ namespace core {
 static uint32 last_debug_oid = 0;
 #endif
 
-_Object::_Object() : refCount(0) {
+_Object::_Object() : refCount_(0) {
 #ifdef WITH_DEBUG_OID
-  _debug_oid = ++last_debug_oid;
-  if (_debug_oid == 0)
+  debug_oid_ = ++last_debug_oid;
+  if (debug_oid_ == 0)
     int set_breakpoint_here = 1;
 #endif
 }
@@ -99,12 +99,12 @@ _Object::~_Object() {
 
 void _Object::incRef() {
 
-  Atomic::Increment32(&refCount);
+  Atomic::Increment32(&refCount_);
 }
 
 void _Object::decRef() {
 
-  if (Atomic::Decrement32(&refCount) == 0)
+  if (Atomic::Decrement32(&refCount_) == 0)
     delete this;
 }
 }

--- a/CoreLibrary/base.h
+++ b/CoreLibrary/base.h
@@ -94,7 +94,7 @@ class _Object;
 // Cannot be a value returned by a function (return C* instead).
 template<class C> class P {
 private:
-  _Object *object;
+  _Object *object_;
 public:
   P();
   P(C *o);
@@ -103,7 +103,7 @@ public:
   C *operator ->() const;
   template<class D> operator D *() const {
 
-    return static_cast<D *>((C *)object);
+    return static_cast<D *>((C *)object_);
   }
   bool operator ==(C *c) const;
   bool operator !=(C *c) const;
@@ -123,19 +123,19 @@ class core_dll _Object {
   friend class _P;
 protected:
 #ifdef ARCH_32
-  uint32 __vfptr_padding_Object;
+  uint32 __vfptr_padding_Object_;
 #endif
-  int32 volatile refCount;
+  int32 volatile refCount_;
   _Object();
 #ifdef WITH_DEBUG_OID
-  uint32 _debug_oid;
+  uint32 debug_oid_;
 #endif
 public:
   virtual ~_Object();
   void incRef();
   virtual void decRef();
 #ifdef WITH_DEBUG_OID
-  uint32 get_debug_oid() const { return _debug_oid; }
+  uint32 get_debug_oid() const { return debug_oid_; }
 #endif
 };
 

--- a/CoreLibrary/base.tpl.cpp
+++ b/CoreLibrary/base.tpl.cpp
@@ -77,77 +77,77 @@
 
 namespace core {
 
-template<class C> inline P<C>::P() : object(NULL) {
+template<class C> inline P<C>::P() : object_(NULL) {
 }
 
-template<class C> inline P<C>::P(C *o) : object(o) {
+template<class C> inline P<C>::P(C *o) : object_(o) {
 
-  if (object)
-    object->incRef();
+  if (object_)
+    object_->incRef();
 }
 
-template<class C> inline P<C>::P(const P<C> &p) : object(p.object) {
+template<class C> inline P<C>::P(const P<C> &p) : object_(p.object_) {
 
-  if (object)
-    object->incRef();
+  if (object_)
+    object_->incRef();
 }
 
 template<class C> inline P<C>::~P() {
 
-  if (object)
-    object->decRef();
+  if (object_)
+    object_->decRef();
 }
 
 template<class C> inline C *P<C>::operator ->() const {
 
-  return (C *)object;
+  return (C *)object_;
 }
 
 template<class C> inline bool P<C>::operator ==(C *c) const {
 
-  return object == c;
+  return object_ == c;
 }
 
 template<class C> inline bool P<C>::operator !=(C *c) const {
 
-  return object != c;
+  return object_ != c;
 }
 
 template<class C> template<class D> inline bool P<C>::operator ==(P<D> &p) const {
 
-  return object == p.object;
+  return object_ == p.object_;
 }
 
 template<class C> template<class D> inline bool P<C>::operator !=(P<D> &p) const {
 
-  return object != p.object;
+  return object_ != p.object_;
 }
 
 template<class C> inline bool P<C>::operator !() const {
 
-  return !object;
+  return !object_;
 }
 
 template<class C> inline P<C>& P<C>::operator =(C *c) {
 
-  if (object == c)
+  if (object_ == c)
     return *this;
-  if (object)
-    object->decRef();
-  if (object = c)
-    object->incRef();
+  if (object_)
+    object_->decRef();
+  if (object_ = c)
+    object_->incRef();
 
   return *this;
 }
 
 template<class C> template<class D> inline P<C> &P<C>::operator =(const P<D> &p) {
 
-  return this->operator =(static_cast<C *>((D *)p.object));
+  return this->operator =(static_cast<C *>((D *)p.object_));
 }
 
 template<class C> inline P<C> &P<C>::operator =(const P<C> &p) {
 
-  return this->operator =((C *)p.object);
+  return this->operator =((C *)p.object_);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/CoreLibrary/pipe.h
+++ b/CoreLibrary/pipe.h
@@ -97,16 +97,16 @@ template<typename T, uint32 _S> class Pipe11 :
 private:
   class Block {
   public:
-    T buffer[_S * sizeof(T)];
-    Block *next;
-    Block(Block *prev) : next(NULL) { if (prev)prev->next = this; }
-    ~Block() { if (next) delete next; }
+    T buffer_[_S * sizeof(T)];
+    Block *next_;
+    Block(Block *prev) : next_(NULL) { if (prev) prev->next_ = this; }
+    ~Block() { if (next_) delete next_; }
   };
-  int32 head;
-  int32 tail;
-  Block *first;
-  Block *last;
-  Block *spare;
+  int32 head_;
+  int32 tail_;
+  Block *first_;
+  Block *last_;
+  Block *spare_;
 protected:
   void _clear();
   T _pop();
@@ -121,7 +121,7 @@ public:
 template<typename T, uint32 _S> class Pipe1N :
   public Pipe11<T, _S> {
 private:
-  CriticalSection popCS;
+  CriticalSection popCS_;
 public:
   Pipe1N();
   ~Pipe1N();
@@ -132,7 +132,7 @@ public:
 template<typename T, uint32 _S> class PipeN1 :
   public Pipe11<T, _S> {
 private:
-  CriticalSection pushCS;
+  CriticalSection pushCS_;
 public:
   PipeN1();
   ~PipeN1();
@@ -143,8 +143,8 @@ public:
 template<typename T, uint32 _S> class PipeNN :
   public Pipe11<T, _S> {
 private:
-  CriticalSection pushCS;
-  CriticalSection popCS;
+  CriticalSection pushCS_;
+  CriticalSection popCS_;
 public:
   PipeNN();
   ~PipeNN();
@@ -182,24 +182,24 @@ template<typename T, uint32 _S, typename Head, typename Tail, class P, template<
 protected:
   class Block {
   public:
-    T buffer[_S];
-    Block *next;
-    Block(Block *prev) : next(NULL) { if (prev)prev->next = this; }
-    ~Block() { if (next) delete next; }
+    T buffer_[_S];
+    Block *next_;
+    Block(Block *prev) : next_(NULL) { if (prev) prev->next_ = this; }
+    ~Block() { if (next_) delete next_; }
   };
-  Block *first;
-  Block *last;
-  Block *spare; // pipes always retain a spare block: if a block is to be deallocated and there is no spare, it becomes the spare
+  Block *first_;
+  Block *last_;
+  Block *spare_; // pipes always retain a spare block: if a block is to be deallocated and there is no spare, it becomes the spare
 
-  Head head; // starts at -1
-  Tail tail; // starts at 0
-  int32 volatile waitingList; // amount of readers that have to wait, negative value indicate free lunch
+  Head head_; // starts at -1
+  Tail tail_; // starts at 0
+  int32 volatile waitingList_; // amount of readers that have to wait, negative value indicate free lunch
 
   Push<T, _S, P> *_push;
   Pop<T, _S, P> *_pop;
 
-  void shrink(); // deallocates the first block when head reaches its end
-  void grow(); // allocate a new last block when tail reaches its end
+  void shrink(); // deallocates the first block when head_ reaches its end
+  void grow(); // allocate a new last block when tail_ reaches its end
 
   Pipe();
 public:

--- a/CoreLibrary/utils.h
+++ b/CoreLibrary/utils.h
@@ -140,7 +140,7 @@ struct SemaTex {
 
 class core_dll SharedLibrary {
 private:
-  shared_object library;
+  shared_object library_;
 public:
   static SharedLibrary *New(const char *fileName);
   SharedLibrary();
@@ -151,16 +151,16 @@ public:
 
 class core_dll Thread {
 private:
-  thread _thread;
-  bool is_meaningful;
+  thread thread_;
+  bool is_meaningful_;
 protected:
   Thread();
 public:
   template<class T> static T *New(thread_function f, void *args);
   static void TerminateAndWait(Thread **threads, uint32 threadCount);
-  static void TerminateAndWait(Thread *_thread);
+  static void TerminateAndWait(Thread *thread);
   static void Wait(Thread **threads, uint32 threadCount);
-  static void Wait(Thread *_thread);
+  static void Wait(Thread *thread);
   static void Sleep(std::chrono::milliseconds ms);
   static void Sleep(std::chrono::system_clock::duration ms) { Sleep(std::chrono::duration_cast<std::chrono::milliseconds>(ms)); }
   static void Sleep(); // inifnite
@@ -173,7 +173,7 @@ public:
 
 class core_dll TimeProbe { // requires Time::Init()
 private:
-  int64 cpu_counts;
+  int64 cpu_counts_;
   int64 getCounts();
 public:
   void set();    // initialize
@@ -183,8 +183,8 @@ public:
 class core_dll Time { // TODO: make sure time stamps are consistent when computed by different cores
   friend class TimeProbe;
 private:
-  static float64 Period;
-  static Timestamp InitTime;
+  static float64 Period_;
+  static Timestamp InitTime_;
 public:
   static void Init(uint32 r); // detects the hardware timing capabilities; r: time resolution in us (on windows xp: max ~1000; use 1000, 2000, 5000 or 10000)
   static Timestamp Get();     // timestamp since 01/01/1970
@@ -201,7 +201,7 @@ public:
 
 class core_dll Semaphore {
 private:
-  semaphore s;
+  semaphore s_;
 protected:
   static const uint32 Infinite;
 public:
@@ -214,7 +214,7 @@ public:
 
 class core_dll Mutex {
 private:
-  mutex m;
+  mutex m_;
 protected:
   static const uint32 Infinite;
 public:
@@ -226,7 +226,7 @@ public:
 
 class core_dll CriticalSection {
 private:
-  critical_section cs;
+  critical_section cs_;
 public:
   CriticalSection();
   ~CriticalSection();
@@ -237,7 +237,7 @@ public:
 class core_dll Timer {
 private:
 #if defined WINDOWS
-  timer t;
+  timer t_;
 #elif defined LINUX
   timer_t timer;
   struct SemaTex sematex;
@@ -254,7 +254,7 @@ public:
 class core_dll Event {
 private:
 #if defined WINDOWS
-  event e;
+  event e_;
 #elif defined LINUX
   // TODO.
 #endif
@@ -295,8 +295,8 @@ uint8 core_dll BSR(word data); // BitScanReverse
 class core_dll FastSemaphore : // lock-free under no contention
   public Semaphore {
 private:
-  int32 volatile count; // minus the number of waiting threads
-  const int32 maxCount; // max number of threads allowed to run
+  int32 volatile count_; // minus the number of waiting threads
+  const int32 maxCount_; // max number of threads allowed to run
 public:
   FastSemaphore(uint32 initialCount, uint32 maxCount); // initialCount >=0
   ~FastSemaphore();
@@ -318,10 +318,10 @@ public:
 
 class core_dll Random {
 private:
-  static int32 r250_index;
-  static int32 r521_index;
-  static uint32 r250_buffer[R250_LEN];
-  static uint32 r521_buffer[R521_LEN];
+  static int32 r250_index_;
+  static int32 r521_index_;
+  static uint32 r250_buffer_[R250_LEN];
+  static uint32 r521_buffer_[R521_LEN];
 public:
   static void Init();
 

--- a/CoreLibrary/utils.tpl.cpp
+++ b/CoreLibrary/utils.tpl.cpp
@@ -89,9 +89,9 @@ namespace core {
 template<typename T> T SharedLibrary::getFunction(const char *functionName) {
   T function = NULL;
 #if defined WINDOWS
-  if (library) {
+  if (library_) {
 
-    function = (T)GetProcAddress(library, functionName);
+    function = (T)GetProcAddress(library_, functionName);
     if (!function) {
 
       DWORD error = GetLastError();
@@ -99,8 +99,8 @@ template<typename T> T SharedLibrary::getFunction(const char *functionName) {
     }
   }
 #elif defined LINUX
-  if (library) {
-    function = (T)dlsym(library, functionName);
+  if (library_) {
+    function = (T)dlsym(library_, functionName);
     if (!function) {
       std::cout << "> Error: unable to find symbol " << functionName << " :" << dlerror() << std::endl;
     }
@@ -115,9 +115,9 @@ template<class T> T *Thread::New(thread_function f, void *args) {
 
   T *t = new T();
 #if defined WINDOWS
-  if (t->_thread = CreateThread(NULL, 0, f, args, 0, NULL))
+  if (t->thread_ = CreateThread(NULL, 0, f, args, 0, NULL))
 #elif defined LINUX
-  if (pthread_create(&t->_thread, NULL, f, args) == 0)
+  if (pthread_create(&t->thread_, NULL, f, args) == 0)
 #endif
     return t;
   delete t;


### PR DESCRIPTION
To address the bug in https://github.com/IIIM-IS/replicode/pull/74 , this pull request changes the spelling of all member variables to add a trailing underscore. This distinguishes them from local variables to avoid coding errors. For more details, see https://github.com/IIIM-IS/replicode/pull/76 .