### PR TITLE
Time::Init: Subtract initial QueryPerformanceCounter value from InitTime_

### DIFF
--- a/CoreLibrary/utils.cpp
+++ b/CoreLibrary/utils.cpp
@@ -411,8 +411,7 @@ std::string Time::ToString_year(Timestamp timestamp) {
   uint64 s = ms / 1000;
   ms = ms % 1000;
 
-  time_t _gmt_time;
-  time(&_gmt_time);
+  time_t _gmt_time = s;
   struct tm   *_t = gmtime(&_gmt_time);
 
   std::string _s = asctime(_t); // _s is: Www Mmm dd hh:mm:ss yyyy but we want: Www Mmm dd yyyy hh:mm:ss:msmsms:ususus


### PR DESCRIPTION
When Replicode starts, `Time::Init` initializes `InitTime_` with the current calendar timestamp in UTC. `Time::Get` (used for `Now()`) calls `QueryPerformanceCounter` to get the high-precision timer in microseconds, and then adds `InitTime_` so that the returned value is a timestamp in UTC. This would work if the `QueryPerformanceCounter` timer returns 0 at the time when Replicode starts. But this timer is actually the time since Windows started, so the returned value can actually be off by several days. (In most places, Replicode only cares about relative differences between timestamps so this hadn't shown up.)

This is easy enough to fix. The first commit in this pull request changes `Time::Init` so that `InitTime_` subtracts the `QueryPerformanceCounter` value from the current calendar timestamp. `Time::Get` behaves exactly as before, but the correct `InitTime_` offset means that the returned timestamps are correct.

In a related issue, `Time::ToString_year` is supposed to print the date string for a timestamp, e.g. "Fri Apr 10 2020 13:02:51:368:767 GMT". Without the fix mentioned above, the timestamp could be off by several days. And yet, the result of `Time::ToString_year` did not seem to be wrong. Why? It turns out that this method was ignoring everything in the supplied timestamp except for its sub-seconds value. Instead, it calls `time()` to get the current calendar time (number of seconds since 01/01/1970) and prints its values, only adding the remaining milliseconds and microseconds from the supplied timestamp. This makes this version of `Time::ToString_year` actually pretty useless. (This hasn't been a problem because it is only called in one place, to print "image taken at" in decompile_objects.txt.) But this is easy enough to fix also. The second commit in this pull request changes `Time::ToString_year` to get the number of seconds since 01/01/1970 from the supplied timestamp instead of calling `time()`. Without the fix in the first commit, the result could have been offset be several days but is now correct.