### PR TITLE
core: Use std::atomic. Remove class Atomic.

### DIFF
--- a/CoreLibrary/base.cpp
+++ b/CoreLibrary/base.cpp
@@ -118,12 +118,12 @@ void _Object::set_detail_oid(uint64 detail_oid) {
 
 void _Object::incRef() {
 
-  Atomic::Increment32(&refCount_);
+  ++refCount_;
 }
 
 void _Object::decRef() {
 
-  if (Atomic::Decrement32(&refCount_) == 0)
+  if (--refCount_ == 0)
     delete this;
 }
 }

--- a/CoreLibrary/base.h
+++ b/CoreLibrary/base.h
@@ -88,6 +88,7 @@
 //#define WITH_DETAIL_OID // Enable get_detail_oid() in every object.
 
 #include <cstdlib>
+#include <atomic>
 
 #include "types.h"
 
@@ -134,7 +135,7 @@ protected:
 #ifdef ARCH_32
   uint32 __vfptr_padding_Object_;
 #endif
-  int32 volatile refCount_;
+  std::atomic_int32_t refCount_;
   _Object();
 #ifdef WITH_DETAIL_OID
   uint64 detail_oid_;

--- a/CoreLibrary/utils.h
+++ b/CoreLibrary/utils.h
@@ -90,6 +90,7 @@
 
 #include <iostream>
 #include <string>
+#include <atomic>
 
 #if defined WINDOWS
 #include <sys/timeb.h>
@@ -277,30 +278,12 @@ public:
   static void Remove(signal_handler h);
 };
 
-class core_dll Atomic {
-public:
-  static int32 Increment32(int32 volatile *v);                               // return the final value of *v
-  static int32 Decrement32(int32 volatile *v);                               // return the final value of *v
-  static int32 CompareAndSwap32(int32 volatile *target, int32 v1, int32 v2); // compares *target with v1, if equal, replace it with v2; return the initial value of *target
-  static int64 CompareAndSwap64(int64 volatile *target, int64 v1, int64 v2);
-  // static word CompareAndSwap(word volatile *target,word v1,word v2);      // uses the right version according to ARCH_xx
-  static int32 Swap32(int32 volatile *target, int32 v);                      // writes v at target; return the initial value of *target
-  static int64 Swap64(int64 volatile *target, int64 v);                      // ifndef ARCH_64, calls CompareAndSwap64(target,v,v)
-// static word Swap(word volatile *target,word v);                             // uses the right version according to ARCH_xx
-#if defined ARCH_64
-  static int64 Increment64(int64 volatile *v);
-  static int64 Decrement64(int64 volatile *v);
-  static int32 Add32(int32 volatile *target, int32 v); // adds v to *target; return the final value of *target
-  static int64 Add64(int64 volatile *target, int64 v);
-#endif
-};
-
 uint8 core_dll BSR(word data); // BitScanReverse
 
 class core_dll FastSemaphore : // lock-free under no contention
   public Semaphore {
 private:
-  int32 volatile count_; // minus the number of waiting threads
+  std::atomic_int32_t count_; // minus the number of waiting threads
   const int32 maxCount_; // max number of threads allowed to run
 public:
   FastSemaphore(uint32 initialCount, uint32 maxCount); // initialCount >=0


### PR DESCRIPTION
The CoreLibrary file utils.cpp has utilities to support Windows or Linux. One of these is the `Atomic` class which allows a thread to change the value of an integer without interference from another thread. This was written before 2010 with specific implementations for Windows or Linux. However, the C++ standard library released in 2011 (called "C++11") has the cross-platform `std::atomic` class. This PR removes the `Atomic` class from CoreLibrary and changes the rest of the code to use `std::atomic`. This way, we don't need to maintain platform-specific code for this facility.